### PR TITLE
Only send US numbers over GVoice

### DIFF
--- a/src/org/cyanogenmod/voiceplus/VoicePlusService.java
+++ b/src/org/cyanogenmod/voiceplus/VoicePlusService.java
@@ -150,6 +150,8 @@ public class VoicePlusService extends Service {
     public int onStartCommand(final Intent intent, int flags, int startId) {
         int ret = super.onStartCommand(intent, flags, startId);
 
+	
+
         if (null == settings.getString("account", null)) {
             stopSelf();
             return ret;
@@ -159,6 +161,13 @@ public class VoicePlusService extends Service {
 
         if (intent == null)
             return ret;
+	
+	String destAddr = intent.getStringExtra("destAddr");
+        String scAddr = intent.getStringExtra("scAddr");
+	if (!scAddr.startsWith("+1") && !destAddr.startsWith("+1")) {
+		stopSelf();
+		return ret;
+	}
 
         // handle an outgoing sms on a background thread.
         if ("android.intent.action.NEW_OUTGOING_SMS".equals(intent.getAction())) {


### PR DESCRIPTION
Google Voice only allows sending SMS to US numbers. On non-US phones,
it makes sense to send normal SMSes through the normal cellular channel,
while sending US SMSes via GVoice. This is, at least, the most common
work flow for non-US phones that use GVoice.

This patch is untested.
