### PR TITLE
Fix & improve country detection for cellular failover.

### DIFF
--- a/src/org/cyanogenmod/voiceplus/VoicePlusService.java
+++ b/src/org/cyanogenmod/voiceplus/VoicePlusService.java
@@ -156,13 +156,14 @@ public class VoicePlusService extends Service {
 
         TelephonyManager tm = (TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE);
         String country = tm.getNetworkCountryIso();
-        if (country == null)
+        if (country.isEmpty())
             country = tm.getSimCountryIso();
-        if (country == null)
+        if (country.isEmpty())
             return address.startsWith("+1"); /* Should never be reached. */
 
-        if (!country.toUpperCase().equals("US") && !address.startsWith("+1"))
+        if (!country.toUpperCase().matches("US|CA") && !address.startsWith("+1"))
             return false;
+
 
         return true;
     }


### PR DESCRIPTION
- Fixes a bug where TelephonyManager and Locale methods are assumed to
  return `null` when they don't know location. They in fact return empty
  strings.
- If in airplane mode with wifi enabled, TelephonyManager methods won't
  detect country, so added a final option to detect country from default
  Locale language.
- Google Voice works not just within USA, but also Canada, without the
  "+1" prefix. Canadian devices are now treated the same as US.
